### PR TITLE
Updated CI-CD to handle the secrets issue

### DIFF
--- a/.github/workflows/docker-CICD-pipeline.yml
+++ b/.github/workflows/docker-CICD-pipeline.yml
@@ -15,13 +15,13 @@ jobs:
       postgres:
         image: postgres:13
         env:
-          POSTGRES_USER: ${{ secrets.POSTGRES_ADMIN_USER }}
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_ADMIN_PASSWORD }}
-          POSTGRES_DB: ${{ secrets.POSTGRES_INSDB }}
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_db
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U ${{ secrets.POSTGRES_ADMIN_USER }}" 
+          --health-cmd "pg_isready -U postgres" 
           --health-interval 10s 
           --health-timeout 5s 
           --health-retries 5
@@ -39,14 +39,22 @@ jobs:
 
       # Step 3: Load environment variables from GitHub Secrets
       - name: Load environment variables
+        env:
+          POSTGRES_ADMIN_USER: ${{ secrets.POSTGRES_ADMIN_USER }}
+          POSTGRES_ADMIN_PASSWORD: ${{ secrets.POSTGRES_ADMIN_PASSWORD }}
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
+          POSTGRES_INSDB: ${{ secrets.POSTGRES_INSDB }}
+          DEBUG: ${{ secrets.DEBUG }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY }}
         run: |
-          echo "POSTGRES_ADMIN_USER=${{ secrets.POSTGRES_ADMIN_USER }}" >> $GITHUB_ENV
-          echo "POSTGRES_ADMIN_PASSWORD=${{ secrets.POSTGRES_ADMIN_PASSWORD }}" >> $GITHUB_ENV
-          echo "POSTGRES_HOST=localhost" >> $GITHUB_ENV  # Since we use a local PostgreSQL Docker container
-          echo "POSTGRES_PORT=5432" >> $GITHUB_ENV
-          echo "POSTGRES_INSDB=${{ secrets.POSTGRES_INSDB }}" >> $GITHUB_ENV
-          echo "DEBUG=${{ secrets.DEBUG }}" >> $GITHUB_ENV
-          echo "SECRET_KEY=${{ secrets.SECRET_KEY }}" >> $GITHUB_ENV
+          echo "POSTGRES_ADMIN_USER=${POSTGRES_ADMIN_USER}" >> $GITHUB_ENV
+          echo "POSTGRES_ADMIN_PASSWORD=${POSTGRES_ADMIN_PASSWORD}" >> $GITHUB_ENV
+          echo "POSTGRES_HOST=${POSTGRES_HOST}" >> $GITHUB_ENV
+          echo "POSTGRES_PORT=${POSTGRES_PORT}" >> $GITHUB_ENV
+          echo "POSTGRES_INSDB=${POSTGRES_INSDB}" >> $GITHUB_ENV
+          echo "DEBUG=${DEBUG}" >> $GITHUB_ENV
+          echo "SECRET_KEY=${SECRET_KEY}" >> $GITHUB_ENV
 
       # Step 4: Install dependencies
       - name: Install dependencies


### PR DESCRIPTION
We can use $GITHUB_ENV to read/use the env variables from secrets directly. No need for explicit